### PR TITLE
Add stdio entrypoint so server can be launched directly

### DIFF
--- a/server.py
+++ b/server.py
@@ -1177,3 +1177,7 @@ publication: {pub['subdomain']}
         "publication": pub["subdomain"],
         "date": today,
     }
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio", show_banner=False)


### PR DESCRIPTION
## Summary

`server.py` defines the FastMCP instance and 29 tools, but has no `__main__` block — running `python3 server.py` loads the module without starting the server. Claude Code (and any MCP client following the README) reports `Failed to connect`.

## Repro

```bash
git clone https://github.com/adelaidasofia/substack-mcp
cd substack-mcp
pip3 install -r requirements.txt
# Register in .mcp.json:
#   "substack": { "command": "python3", "args": ["/path/to/server.py"] }
claude mcp list
# substack: ... - ✗ Failed to connect
```

Sending an MCP `initialize` JSON-RPC over stdio also returns no response — the process exits as soon as stdin closes because nothing is reading from it.

## Fix

Add the standard FastMCP stdio entrypoint at the end of `server.py`:

```python
if __name__ == "__main__":
    mcp.run(transport="stdio", show_banner=False)
```

`show_banner=False` keeps stdout clean for the MCP protocol (FastMCP prints to stderr by default, but the banner can leak into stdout in some setups).

## Verified

After the patch:
```
$ claude mcp list
substack: ... - ✓ Connected
```
And `test_connection` returns the expected profile payload over the live MCP transport.