### PR TITLE
fix: pass order_by/order_direction defaults on list_published (closes #5)

### DIFF
--- a/server.py
+++ b/server.py
@@ -763,7 +763,12 @@ async def list_published(
         result = await _get(
             f"{_pub_base(pub)}/post_management/published",
             pub,
-            params={"offset": "0", "limit": str(limit)},
+            params={
+                "offset": "0",
+                "limit": str(limit),
+                "order_by": "post_date",
+                "order_direction": "desc",
+            },
         )
     except Exception:
         # Fallback: use the posts endpoint


### PR DESCRIPTION
## Summary
Substack now rejects `GET /post_management/published` with HTTP 400 when `order_by` and `order_direction` are missing. `get_top_posts` already passes `order_by=reaction_count, order_direction=desc` and works fine — `list_published` was sending only `offset` + `limit` and getting rejected.

Fix: pass `order_by=post_date, order_direction=desc` as the canonical defaults so the endpoint behaves as documented.

## Test
Verified locally against `adelaidasofia` publication — `list_published(limit=5)` now returns the latest posts instead of HTTP 400.

Closes #5.