### PR TITLE
Add Claude Code plugin marketplace manifests

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://code.claude.com/schemas/marketplace.json",
+  "name": "substack-mcp",
+  "owner": {
+    "name": "Mycelium AI",
+    "url": "https://myceliumai.co"
+  },
+  "plugins": [
+    {
+      "name": "substack-mcp",
+      "source": "./",
+      "description": "FastMCP server for Substack: publish Notes and posts, pull analytics, manage drafts, bridge Obsidian vault drafts to Substack, and generate visual cards with pluggable image generators."
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "substack-mcp",
+  "description": "FastMCP server for Substack: publish Notes and posts, pull analytics, manage drafts, bridge Obsidian vault drafts to Substack, and generate visual cards with pluggable image generators.",
+  "version": "0.1.0",
+  "author": {
+    "name": "Mycelium AI",
+    "url": "https://myceliumai.co"
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "substack": {
+      "command": "python3",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server.py"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -56,12 +56,21 @@ substack__capture_analytics_to_vault  -- snapshot analytics to vault markdown
 
 ## Install
 
+Open Claude Code, paste:
+
+    /plugin marketplace add adelaidasofia/substack-mcp
+    /plugin install substack-mcp@substack-mcp
+
+<details><summary>Legacy install</summary>
+
 ```bash
 git clone https://github.com/adelaidasofia/substack-mcp
 cd substack-mcp
 pip3 install -r requirements.txt
 python3 -c "import server; print('OK')"
 ```
+
+</details>
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` + `.claude-plugin/plugin.json` so the repo registers as a Claude Code plugin marketplace.
- Adds `.mcp.json` at the repo root pointing the `substack` MCP server at `${CLAUDE_PLUGIN_ROOT}/server.py`.
- Replaces the `## Install` block in the README with a one-line `/plugin install` command; legacy install path moved to a `<details>` collapsible.

## Install (after merge)
```
/plugin marketplace add adelaidasofia/substack-mcp
/plugin install substack-mcp@substack-mcp
```