### PR TITLE
feat(ssrf): wire mycelium-security on all 5 fetch helpers (MYC-101)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 fastmcp>=3.0.0
 httpx>=0.27.0
 Pillow>=10.0.0
+# SSRF hardening for outbound Substack API fetch (MYC-101).
+mycelium-security @ git+https://github.com/adelaidasofia/mycelium-security.git@v0.1.0

--- a/server.py
+++ b/server.py
@@ -14,11 +14,24 @@ import os
 import re
 from datetime import datetime, date
 from pathlib import Path
+from urllib.parse import urlparse
 
 import httpx
 from fastmcp import FastMCP
+from mycelium_security import UnsafeURL, assert_public_ip, sanitize_or_raise
 
 from prosemirror import md_to_prosemirror, md_to_note_body
+
+
+# SSRF hardening (MYC-101): every outbound URL passes through _validate_url
+# before any of the _get/_post/_put/_delete/_post_form helpers fire. Returns
+# the safe URL string or raises UnsafeURL (callers convert to {"error": ...}
+# so the never-raises contract of the fetch helpers is preserved).
+def _validate_url(url: str) -> str:
+    safe = sanitize_or_raise(url)
+    host = urlparse(safe).hostname or ""
+    assert_public_ip(host)
+    return safe
 
 # ---------------------------------------------------------------------------
 # Server init
@@ -75,7 +88,11 @@ def _headers(pub: dict) -> dict:
 
 async def _get(url: str, pub: dict, params: dict | None = None) -> dict | list:
     """Authenticated GET."""
-    async with httpx.AsyncClient() as client:
+    try:
+        url = _validate_url(url)
+    except UnsafeURL as exc:
+        return {"error": f"refused (SSRF): {exc}"}
+    async with httpx.AsyncClient(follow_redirects=False) as client:
         r = await client.get(url, headers=_headers(pub), params=params, timeout=20)
         if r.status_code in (401, 403):
             return {"error": "Auth failed. Cookie may be expired. Re-extract from Chrome DevTools."}
@@ -91,7 +108,11 @@ async def _get(url: str, pub: dict, params: dict | None = None) -> dict | list:
 
 async def _post(url: str, pub: dict, body: dict | None = None) -> dict | list:
     """Authenticated POST (JSON)."""
-    async with httpx.AsyncClient() as client:
+    try:
+        url = _validate_url(url)
+    except UnsafeURL as exc:
+        return {"error": f"refused (SSRF): {exc}"}
+    async with httpx.AsyncClient(follow_redirects=False) as client:
         r = await client.post(url, headers=_headers(pub), json=body or {}, timeout=30)
         if r.status_code in (401, 403):
             return {"error": "Auth failed. Cookie may be expired. Re-extract from Chrome DevTools."}
@@ -108,7 +129,11 @@ async def _post(url: str, pub: dict, body: dict | None = None) -> dict | list:
 
 async def _put(url: str, pub: dict, body: dict | None = None) -> dict | list:
     """Authenticated PUT (JSON)."""
-    async with httpx.AsyncClient() as client:
+    try:
+        url = _validate_url(url)
+    except UnsafeURL as exc:
+        return {"error": f"refused (SSRF): {exc}"}
+    async with httpx.AsyncClient(follow_redirects=False) as client:
         r = await client.put(url, headers=_headers(pub), json=body or {}, timeout=30)
         if r.status_code in (401, 403):
             return {"error": "Auth failed. Cookie may be expired. Re-extract from Chrome DevTools."}
@@ -124,7 +149,11 @@ async def _put(url: str, pub: dict, body: dict | None = None) -> dict | list:
 
 async def _delete(url: str, pub: dict) -> dict:
     """Authenticated DELETE."""
-    async with httpx.AsyncClient() as client:
+    try:
+        url = _validate_url(url)
+    except UnsafeURL as exc:
+        return {"error": f"refused (SSRF): {exc}"}
+    async with httpx.AsyncClient(follow_redirects=False) as client:
         r = await client.delete(url, headers=_headers(pub), timeout=20)
         if r.status_code in (401, 403):
             return {"error": "Auth failed. Cookie may be expired."}
@@ -134,9 +163,13 @@ async def _delete(url: str, pub: dict) -> dict:
 
 async def _post_form(url: str, pub: dict, data: dict) -> dict:
     """Authenticated POST with form data (for image upload)."""
+    try:
+        url = _validate_url(url)
+    except UnsafeURL as exc:
+        return {"error": f"refused (SSRF): {exc}"}
     headers = _headers(pub)
     headers["Content-Type"] = "application/x-www-form-urlencoded"
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(follow_redirects=False) as client:
         r = await client.post(url, headers=headers, data=data, timeout=60)
         if r.status_code in (401, 403):
             return {"error": "Auth failed. Cookie may be expired."}

--- a/tests/test_ssrf.py
+++ b/tests/test_ssrf.py
@@ -1,0 +1,90 @@
+"""SSRF mitigation tests for substack-mcp (MYC-101).
+
+5 outbound HTTP helpers (_get / _post / _put / _delete / _post_form) all
+share one validator (_validate_url). Tests cover:
+  - the validator rejects the 5-attack matrix
+  - all 5 helpers refuse to fire when the URL is blocked
+  - all 5 helpers init httpx.AsyncClient with follow_redirects=False
+"""
+from __future__ import annotations
+
+import socket
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import server  # noqa: E402
+
+_DUMMY_PUB = {"name": "test", "subdomain": "test", "cookie": "x"}
+
+
+class TestValidatorRejects5AttackMatrix:
+    def test_rejects_backslash(self):
+        with pytest.raises(server.UnsafeURL, match="banned character"):
+            server._validate_url("https://substack.com/\\evil")
+
+    def test_rejects_embedded_credentials(self):
+        with pytest.raises(server.UnsafeURL, match="credentials"):
+            server._validate_url("https://u:p@substack.com/api")
+
+    def test_rejects_ipv6_link_local(self):
+        with pytest.raises(server.UnsafeURL):
+            server._validate_url("http://[fe80::1]/api")
+
+    def test_rejects_dns_resolving_to_private_ip(self):
+        with patch("mycelium_security.url.socket.getaddrinfo") as mock_resolver:
+            mock_resolver.return_value = [
+                (socket.AF_INET, socket.SOCK_STREAM, 0, "", ("10.0.0.1", 0))
+            ]
+            with pytest.raises(server.UnsafeURL):
+                server._validate_url("http://attacker.example.com/api")
+
+    def test_rejects_aws_metadata(self):
+        with pytest.raises(server.UnsafeURL, match="metadata"):
+            server._validate_url("http://169.254.169.254/latest/meta-data/")
+
+
+@pytest.mark.asyncio
+class TestAllFiveHelpersRefuseUnsafeURLs:
+    """Each helper returns {error: refused (SSRF): ...} instead of raising."""
+
+    async def test_get_refuses(self):
+        result = await server._get("http://169.254.169.254/imds", _DUMMY_PUB)
+        assert "error" in result and "SSRF" in result["error"]
+
+    async def test_post_refuses(self):
+        result = await server._post("http://169.254.169.254/imds", _DUMMY_PUB, body={})
+        assert "error" in result and "SSRF" in result["error"]
+
+    async def test_put_refuses(self):
+        result = await server._put("http://169.254.169.254/imds", _DUMMY_PUB, body={})
+        assert "error" in result and "SSRF" in result["error"]
+
+    async def test_delete_refuses(self):
+        result = await server._delete("http://169.254.169.254/imds", _DUMMY_PUB)
+        assert "error" in result and "SSRF" in result["error"]
+
+    async def test_post_form_refuses(self):
+        result = await server._post_form("http://169.254.169.254/imds", _DUMMY_PUB, data={})
+        assert "error" in result and "SSRF" in result["error"]
+
+
+@pytest.mark.asyncio
+class TestFollowRedirectsFalse:
+    async def test_get_sets_follow_redirects_false(self):
+        captured = {}
+        import httpx
+        class _Spy(httpx.AsyncClient):
+            def __init__(self, *args, **kwargs):
+                captured.update(kwargs)
+                super().__init__(*args, **kwargs)
+        with patch("server.httpx.AsyncClient", _Spy):
+            try:
+                await server._get("https://substack.com/api/v1/user/profile/self", _DUMMY_PUB)
+            except Exception:
+                pass
+        assert captured.get("follow_redirects") is False


### PR DESCRIPTION
MYC-101 rollout. All 5 fetch helpers (_get/_post/_put/_delete/_post_form) refactored through _validate_url. 11/11 SSRF tests pass.