### PR TITLE
chore(ci): pin actions to full commit SHA

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98  # v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enable auto-merge on qualifying updates

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -31,8 +31,8 @@ jobs:
   pip-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.11'
       - name: pip-audit (block on known advisories)


### PR DESCRIPTION
Pins 3 unpinned GitHub Actions references to full commit SHAs (supply-chain hardening). Re-derived against current main. Auto: pin-github-actions-to-sha.